### PR TITLE
Сетевое взаимодействие Pod, сервисы

### DIFF
--- a/kubernetes-networks/deployment.yaml
+++ b/kubernetes-networks/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx2-deployment
+  namespace: homework
+  labels:
+    app: nginx
+    homework: two
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx2
+  template:
+    metadata:
+      labels:
+        app: nginx2
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: homework
+                    operator: In
+                    values: 
+                    - "true"
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 8000
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+          initialDelaySeconds: 6
+          periodSeconds: 5
+        lifecycle:
+          #postStart:
+          #  exec:
+          #    command: ["/bin/sh", "-c", "date; echo 'PreStop hook started'; sleep 10"]
+          preStop:
+            exec:
+             command:
+              - /bin/sh
+              - -c
+              - |
+                date
+                echo 'PreStop hook started'
+                rm -f /homework/index.html
+                rm -f /usr/share/nginx/html/index.html
+                echo "удалили файлики index.html"
+                date
+                echo "-----"
+        volumeMounts:
+        - name: workdir
+          #mountPath: /usr/share/nginx/html
+          mountPath: /homework
+        command: ["/bin/sh", "-c"]
+        args: 
+        - |
+          sed -i 's/listen[[:space:]]*80;/listen 8000;/' /etc/nginx/conf.d/default.conf
+          cp -r /homework/* /usr/share/nginx/html/ && nginx -g 'daemon off;'
+      # These containers are run during pod initialization
+      initContainers:
+      - name: install
+        image: busybox:1.28
+        command:
+        - wget
+        - "-O"
+        - "/init/index.html"
+        - http://info.cern.ch
+        volumeMounts:
+        - name: workdir
+          mountPath: "/init"
+      dnsPolicy: Default
+      volumes:
+      - name: workdir
+        emptyDir: {}
+      restartPolicy: Always
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+

--- a/kubernetes-networks/ingress-nginx.yaml
+++ b/kubernetes-networks/ingress-nginx.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+data:
+  allow-snippet-annotations: "true"
+  enable-annotation-validations: "false"
+  annotations-risk-level: "Critical"

--- a/kubernetes-networks/ingress.yaml
+++ b/kubernetes-networks/ingress.yaml
@@ -3,25 +3,15 @@ kind: Ingress
 metadata:
   name: ingress1
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /index.html
-    #nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^/homepage$ /index.html break;
 spec:
   rules:
   - host: homework.otus
     http:
       paths:
       - pathType: Prefix
-        path: "/index.html"
-        backend:
-          service:
-            name: nginx2-service
-            port:
-              number: 80
-  - host: homework.otus
-    http:
-      paths:
-      - pathType: Prefix
-        path: "/homepage"
+        path: /
         backend:
           service:
             name: nginx2-service

--- a/kubernetes-networks/ingress.yaml
+++ b/kubernetes-networks/ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress1
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /index.html
+    #nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  rules:
+  - host: homework.otus
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/index.html"
+        backend:
+          service:
+            name: nginx2-service
+            port:
+              number: 80
+  - host: homework.otus
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/homepage"
+        backend:
+          service:
+            name: nginx2-service
+            port:
+              number: 80

--- a/kubernetes-networks/namespace.yaml
+++ b/kubernetes-networks/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-networks/service.yaml
+++ b/kubernetes-networks/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx2-service
+spec:
+  selector:
+    app: nginx2
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+  type: ClusterIP


### PR DESCRIPTION
# Выполнено ДЗ №3

 - [ X] Основное ДЗ
 - [ X] Задание со *

## В процессе сделано:
Изменить readiness-пробу в манифесте deployment.yaml из
прошлого ДЗ на httpGet, вызывающую URL /index.html
● Необходимо создать манифест service.yaml, описывающий сервис
типа ClusterIP, который будет направлять трафик на поды,
управляемые вашим deployment
● Установить в кластер ingress-контроллер nginx
● Создать манифест ingress.yaml, в котором будет описан объект
типа ingress, направляющий все http запросы к хосту
homework.otus на ранее созданный сервис. В результате запрос
http://homework.otus/index.html должен отдавать код html
страницы, находящейся в подах
●* Доработать манифест ingress.yaml, описав в нем rewrite-правила
так, чтобы обращение по адресу http://homework.otus/homepage
форвардилось на http://homework.otus/index.html


## Как запустить проект:
kubectl apply -f deployment.yaml 
kubectl apply -f service.yaml 
echo '192.168.49.2     homework.otus' >> /etc/hosts
kubectl apply -f ingress.yaml 

## Как проверить работоспособность:
http://homework.otus/homepage

## PR checklist:
 - [X ] Выставлен label с темой домашнего задания
