### PR TITLE
Volumes, StorageClass, PV, PVC

### DIFF
--- a/kubernetes-volumes/cm.yaml
+++ b/kubernetes-volumes/cm.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+data:
+  app.properties: |
+    database.host=postgres
+    database.port=5432
+    app.name=my-application
+    log.level=INFO
+    uuu=ttt
+  nginx.conf: |
+    server {
+        listen 80;
+        server_name localhost;
+        
+        location / {
+            proxy_pass http://localhost:8080;
+        }
+    }

--- a/kubernetes-volumes/deployment.yaml
+++ b/kubernetes-volumes/deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx2-deployment
+  namespace: homework
+  labels:
+    app: nginx
+    homework: four
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx2
+  template:
+    metadata:
+      labels:
+        app: nginx2
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: homework
+                    operator: In
+                    values: 
+                    - "true"
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 8000
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+          initialDelaySeconds: 6
+          periodSeconds: 5
+        lifecycle:
+          #postStart:
+          #  exec:
+          #    command: ["/bin/sh", "-c", "date; echo 'PreStop hook started'; sleep 10"]
+          preStop:
+            exec:
+             command:
+              - /bin/sh
+              - -c
+              - |
+                date
+                echo 'PreStop hook started'
+                rm -f /homework/index.html
+                rm -f /usr/share/nginx/html/index.html
+                echo "удалили файлики index.html"
+                date
+                echo "-----"
+        volumeMounts:
+        - name: workdir
+          #mountPath: /usr/share/nginx/html
+          mountPath: /homework
+        - name: config-volume
+          mountPath: /homework/conf
+          readOnly: true
+        command: ["/bin/sh", "-c"]
+        args: 
+        - |
+          sed -i 's/listen[[:space:]]*80;/listen 8000;/' /etc/nginx/conf.d/default.conf
+          cp -r /homework/* /usr/share/nginx/html/ && nginx -g 'daemon off;'
+      # These containers are run during pod initialization
+      initContainers:
+      - name: install
+        image: busybox:1.28
+        command:
+        - wget
+        - "-O"
+        - "/init/index.html"
+        - http://info.cern.ch
+        volumeMounts:
+        - name: workdir
+          mountPath: "/init"
+      dnsPolicy: Default
+      volumes:
+      - name: workdir
+        persistentVolumeClaim:
+          claimName: pv-claim
+      - name: config-volume
+        configMap:
+          name: app-config
+      
+      restartPolicy: Always
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+

--- a/kubernetes-volumes/ingress.yaml
+++ b/kubernetes-volumes/ingress.yaml
@@ -1,0 +1,49 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress1
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /index.html
+    #nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  rules:
+  - host: homework.otus
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/index.html"
+        backend:
+          service:
+            name: nginx2-service
+            port:
+              number: 80
+  - host: homework.otus
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/homepage"
+        backend:
+          service:
+            name: nginx2-service
+            port:
+              number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress2-cm
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /conf/app.properties
+    #nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  rules:
+  - host: homework.otus
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/conf/file"
+        backend:
+          service:
+            name: nginx2-service
+            port:
+              number: 80

--- a/kubernetes-volumes/namespace.yaml
+++ b/kubernetes-volumes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-volumes/pvc.yaml
+++ b/kubernetes-volumes/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pv-claim
+spec:
+  storageClassName: my-storage-class
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Mi

--- a/kubernetes-volumes/service.yaml
+++ b/kubernetes-volumes/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx2-service
+spec:
+  selector:
+    app: nginx2
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+  type: ClusterIP

--- a/kubernetes-volumes/storage-provisioner-rbac.yaml
+++ b/kubernetes-volumes/storage-provisioner-rbac.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: storage-provisioner-full
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["persistentvolumes"]
+  verbs: ["get", "list", "watch", "create", "delete"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: storage-provisioner-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: storage-provisioner-full
+subjects:
+- kind: ServiceAccount
+  name: storage-provisioner
+  namespace: kube-system

--- a/kubernetes-volumes/storageClass.yaml
+++ b/kubernetes-volumes/storageClass.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    defaultVolumeType: local
+  name: my-storage-class
+provisioner: k8s.io/minikube-hostpath
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
# Выполнено ДЗ №

 - [X ] Основное ДЗ
 - [ X] Задание со *

## В процессе сделано:
Создать манифест pvc.yaml, описывающий
PersistentVolumeClaim, запрашивающий хранилище с
storageClass по-умолчанию
● Создать манифест cm.yaml для объекта типа configMap,
описывающий произвольный набор пар ключ-значение
● В манифесте deployment.yaml изменить спецификацию
volume типа emptyDir, который монтируется в init и
основной контейнер, на pvc, созданный в предыдущем
пункте
● В манифесте deployment.yaml добавить монтирование
ранее созданного configMap как volume к основному
контейнеру пода в директорию /homework/conf, так, чтобы
его содержимое можно было получить, обратившись по url
/conf/file
Задание с *
● Создать манифест storageClass.yaml описывающий объект
типа storageClass с provisioner
https://k8s.io/minikube-hostpath и reclaimPolicy Retain
● Изменить манифест pvc.yaml так, чтобы в нем
запрашивалось хранилище созданного вами storageClass-
а

## Как запустить проект:
kubectl config set-context --current --namespace=homework

kubectl get sc standard -o yaml 
kubectl apply -f cm.yaml 
kubectl apply -f pvc.yaml 
kubectl apply -f deployment.yaml 
kubectl apply -f ingress.yaml 

minikube addons enable storage-provisioner
/*# не хватало прав на создание persistentvolumeclaims с кастомным storageClass*/
kubectl apply -f storage-provisioner-rbac.yaml 
kubectl get clusterrole,clusterrolebinding | grep storage-provisioner

kubectl apply -f pvc.yaml 
kubectl apply -f deployment.yaml 

## Как проверить работоспособность:
 - , перейти по http://homework.otus/conf/file

## PR checklist:
 - [X ] Выставлен label с темой домашнего задания
